### PR TITLE
turnoff periodic logging when log interval is set to a value <= 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Executor can:
 
   * Terminate on signal or after a timeout via /x/net/context
   * Output a message on an interval if the program is still running.
+    The periodic message can be turned off by setting `LogInterval` of executor to a value <= 0
   * Capture split-stream stdio, and make it easier to get at io pipes.
 
 Example:

--- a/executor.go
+++ b/executor.go
@@ -6,6 +6,7 @@
 //
 //   * Terminate on signal or after a timeout via /x/net/context
 //   * Output a message on an interval if the program is still running.
+//     The periodic message can be turned off by setting `LogInterval` of executor to a value <= 0
 //   * Capture split-stream stdio, and make it easier to get at io pipes.
 //
 // Example:

--- a/executor.go
+++ b/executor.go
@@ -155,7 +155,9 @@ func (e *Executor) Start() error {
 		return err
 	}
 
-	go e.logInterval()
+	if e.LogInterval > 0 {
+		go e.logInterval()
+	}
 
 	return nil
 }

--- a/executor_test.go
+++ b/executor_test.go
@@ -146,6 +146,35 @@ func (es *execSuite) TestLogger(c *C) {
 	c.Assert(results[0], Equals, "%v has been running for %v")
 }
 
+func (es *execSuite) TestLoggerZeroOrNegativeLogInterval(c *C) {
+	results := []string{}
+	loggerFunc := func(s string, args ...interface{}) {
+		results = append(results, s)
+	}
+
+	cmd := exec.Command("/bin/sleep", "2")
+	e := New(cmd)
+	e.LogFunc = loggerFunc
+	e.LogInterval = 0
+	c.Assert(e.Start(), IsNil)
+	time.Sleep(2 * time.Second)
+	er, _ := e.Wait(context.Background())
+	c.Assert(er.ExitStatus, Equals, 0)
+	c.Assert(er.Runtime > 2*time.Second, Equals, true)
+	c.Assert(len(results), Equals, 0)
+
+	cmd = exec.Command("/bin/sleep", "2")
+	e = New(cmd)
+	e.LogFunc = loggerFunc
+	e.LogInterval = -1
+	c.Assert(e.Start(), IsNil)
+	time.Sleep(2 * time.Second)
+	er, _ = e.Wait(context.Background())
+	c.Assert(er.ExitStatus, Equals, 0)
+	c.Assert(er.Runtime > 2*time.Second, Equals, true)
+	c.Assert(len(results), Equals, 0)
+}
+
 func (es *execSuite) TestString(c *C) {
 	e := New(exec.Command(cmd[0], cmd[1:]...))
 	c.Assert(e.String(), Equals, "[/bin/sleep 200000000] (/bin/sleep) (pid: 0)")


### PR DESCRIPTION
/cc @erikh 

This will be useful for really long running job and avoid filling up log buffer. And also when user may not want a periodic logs mix up with other service logs, which was the case for me where I would like logs from a ansible run (done through executor) to be logged and recorded.

WDYT?
